### PR TITLE
[CF-1] sync User Directory on user logon

### DIFF
--- a/lib/accounts/Accounts.php
+++ b/lib/accounts/Accounts.php
@@ -10,6 +10,16 @@ use NUCSSACore\Utils\Logger;
 class Accounts {
   public function construct(){}
 
+  public function signin($user, $pass){
+    if ((new UserDirectory)->authenticateUser($user, $pass)){
+      // sync LDAP on user login
+      $this->syncFromDirectory();
+      return true;
+    } else {
+      return false;
+    }
+  }
+
   /**
    * sync users and groups from LDAP server to wordpress database
    */


### PR DESCRIPTION
#1 
Synchronize LDAP User Directory with local db upon user logon. 
This ensures we have the latest user-group-membership information to interact with. 