### PR TITLE
limit club info block to only be used once in a post

### DIFF
--- a/assets/js/gutenberg/blocks/club-info/edit.js
+++ b/assets/js/gutenberg/blocks/club-info/edit.js
@@ -19,7 +19,8 @@ const ClubInfoEdit = ({className, thumbnail, clubName, workshop, excerpt}) => {
         </div>
       </div>
       <div className="hover-help-message">
-        This block is for displaying of information only, to edit the block, fill in <strong>Featured Image</strong>, <strong>Workshop Schedule</strong>, and <strong>Excerpt</strong> in sidebar <strong>Document</strong> Tab.
+        这个block仅用来展示社团信息卡片效果, 删除此block对页面不会有任何影响。<br />
+        请填写右侧sidebar中的<strong>Featured Image</strong>, <strong>Workshop Schedule</strong>, and <strong>Excerpt</strong> in <strong>Document</strong> Tab.
       </div>
     </div>
   );


### PR DESCRIPTION
Limit the following block to only be able to be inserted once per post: 
![image](https://user-images.githubusercontent.com/871037/64069897-28625c80-cc22-11e9-8ecf-65107821cdcf.png)
